### PR TITLE
Fix PID constructor parameter order & target heading 

### DIFF
--- a/RUB_V1.ino
+++ b/RUB_V1.ino
@@ -245,9 +245,10 @@ void loop(){
   printDebugInfo();
 
   // Make sure your target heading is aligned wiht your initial heading
-  targetHeading = heading;
-  
-}
+ if(!beginPath){ 
+	 targetHeading = heading;
+ }
+
 
 // Primitives
 

--- a/RUB_V1.ino
+++ b/RUB_V1.ino
@@ -80,7 +80,7 @@ double targetHeading = 0.0;       // Heading to align with (for moving and turni
 
 double motorSpeedOffset = 0;
 double Kp = 1.0, Ki = 0, Kd = 0.0;
-PID alignPID(&targetHeading, &motorSpeedOffset, &heading, Kp, Ki, Kd, DIRECT);
+PID alignPID(&heading, &motorSpeedOffset, &targetHeading Kp, Ki, Kd, DIRECT);
 
 // ---------------  Miscellaneous  ---------------
 


### PR DESCRIPTION
PID initialization calls for input, output, and setpoint in code. Previous code was setting target heading as the input and the heading as the setpoint.

TargetHeading is being overwritten every loop iteration. It now only resets to the current heading when the robot is not executing a path, preventing interference with turns and movements.